### PR TITLE
Enhance the branding of eventyay-talk plugin for videos and change to own naming conventions

### DIFF
--- a/pretalx_venueless/apps.py
+++ b/pretalx_venueless/apps.py
@@ -6,13 +6,13 @@ from . import __version__
 
 class PluginApp(AppConfig):
     name = "pretalx_venueless"
-    verbose_name = "Venueless integration"
+    verbose_name = "Eventyay video integration"
 
     class PretalxPluginMeta:
-        name = gettext_lazy("Venueless integration")
-        author = "Tobias Kunze"
+        name = gettext_lazy("Eventyay video integration")
+        author = "Eventyay"
         description = gettext_lazy(
-            "Venueless integration in pretalx: Notify venueless about new schedule releases!"
+            "Eventyay video integration in pretalx: Notify eventyay about new schedule releases!"
         )
         visible = True
         version = __version__

--- a/pretalx_venueless/forms.py
+++ b/pretalx_venueless/forms.py
@@ -8,14 +8,14 @@ from .models import VenuelessSettings
 class VenuelessSettingsForm(I18nModelForm):
     token = forms.CharField(
         help_text=_(
-            "Generate a token with the trait 'world:api' in the Config -> Token Generator menu in Venueless. Leave empty to leave unchanged."
+            "Generate a token with the trait 'world:api' in the Config -> Token Generator menu in Eventyay video. Leave empty to leave unchanged."
         ),
-        label=_("Venueless Token"),
+        label=_("Eventyay video Token"),
         required=True,
     )
     url = forms.URLField(
-        help_text=_("URL of your Venueless event"),
-        label=_("Venueless URL"),
+        help_text=_("URL of your Eventyay video event"),
+        label=_("Eventyay video URL"),
         required=True,
     )
     return_url = forms.CharField(widget=forms.HiddenInput(), required=False)

--- a/pretalx_venueless/models.py
+++ b/pretalx_venueless/models.py
@@ -13,15 +13,15 @@ class VenuelessSettings(models.Model):
     )
     token = models.TextField(
         help_text=_(
-            "Generate a token with the trait 'world:api' in the Config -> Token Generator menu in Venueless. Leave empty to leave unchanged."
+            "Generate a token with the trait 'world:api' in the Config -> Token Generator menu in Eventyay video. Leave empty to leave unchanged."
         ),
-        verbose_name=_("Venueless Token"),
+        verbose_name=_("Eventyay video Token"),
         null=True,
         blank=True,  # for easier get_or_create
     )
     url = models.URLField(
-        help_text=_("URL of your Venueless event"),
-        verbose_name=_("Venueless URL"),
+        help_text=_("URL of your Eventyay video event"),
+        verbose_name=_("Eventyay video URL"),
         null=True,
         blank=True,  # for easier get_or_create
     )
@@ -30,29 +30,29 @@ class VenuelessSettings(models.Model):
     # settings required for join URLs
     show_join_link = models.BooleanField(
         help_text=_(
-            "If you enable this feature, speakers will find a venueless join button on their profile pages."
+            "If you enable this feature, speakers will find a Eventyay video join button on their profile pages."
         ),
         verbose_name=_("Show join button"),
         default=False,
     )
     join_url = models.URLField(
         help_text=_("URL used for sign-up links"),
-        verbose_name=_("Venueless URL"),
+        verbose_name=_("Eventyay video URL"),
         null=True,
         blank=True,
     )
     secret = models.TextField(
-        verbose_name=_("Venueless secret"),
+        verbose_name=_("Eventyay video secret"),
         null=True,
         blank=True,
     )
     issuer = models.TextField(
-        verbose_name=_("Venueless issuer"),
+        verbose_name=_("Eventyay video issuer"),
         null=True,
         blank=True,
     )
     audience = models.TextField(
-        verbose_name=_("Venueless audience"),
+        verbose_name=_("Eventyay video audience"),
         null=True,
         blank=True,
     )

--- a/pretalx_venueless/signals.py
+++ b/pretalx_venueless/signals.py
@@ -32,7 +32,7 @@ def navbar_info(sender, request, **kwargs):
 
     return [
         {
-            "label": _("Venueless"),
+            "label": _("Eventyay video"),
             "url": reverse(
                 "plugins:pretalx_venueless:settings",
                 kwargs={

--- a/pretalx_venueless/templates/pretalx_venueless/settings.html
+++ b/pretalx_venueless/templates/pretalx_venueless/settings.html
@@ -18,31 +18,31 @@
 {% block content %}
 
     {% if connect_in_progress %}
-        <h2>{% trans "Confirm your Venueless connection" %}</h2>
+        <h2>{% trans "Confirm your Eventyay video connection" %}</h2>
         <div class="alert alert-info">
             <div>
                 {% blocktranslate trimmed %}
-                    <b>Venueless</b> is asking to connect to your pretalx event. If you confirm
-                    this connection, pretalx will notify Venueless about all schedule changes.
+                    <b>Eventyay video</b> is asking to connect to your pretalx event. If you confirm
+                    this connection, pretalx will notify Eventyay video about all schedule changes.
                 {% endblocktranslate %}
             </div>
         </div>
     {% else %}
-        <h2>{% trans "Venueless" %}</h2>
+        <h2>{% trans "Eventyay video" %}</h2>
     {% endif %}
     {% if last_push %}
         <div class="alert alert-success">
             {% blocktranslate trimmed with last_push=last_push %}
-                Successfully connected to venueless. Data was last pushed on {{ last_push }}.
+                Successfully connected to Eventyay video. Data was last pushed on {{ last_push }}.
             {% endblocktranslate %}
         </div>
     {% elif not connect_in_progress %}
         <div class="alert alert-warning">
             <div>
                 {% blocktranslate trimmed %}
-                    Setting up the connection with Venueless will configure the pretalx settings
-                    in Venueless, and will automatically push schedule changes to venueless users.
-                    Please use Venueless to begin this process. Go to <b>Config → Event</b> in Venueless,
+                    Setting up the connection with Eventyay video will configure the pretalx settings
+                    in Eventyay video, and will automatically push schedule changes to Eventyay video users.
+                    Please use Eventyay video to begin this process. Go to <b>Config → Event</b> in Eventyay video,
                     and enter the following settings to create the connection:
                 {% endblocktranslate %}
                 <ul>
@@ -62,7 +62,7 @@
         <p>
             {% blocktranslate trimmed %}
                 These settings will get filled in automatically when you set up
-                your event with venueless. Please follow the instructions at the
+                your event with Eventyay video. Please follow the instructions at the
                 top of this page!
             {% endblocktranslate %}
         </p>
@@ -77,7 +77,7 @@
         <p>
             {% blocktranslate trimmed %}
                 These settings are only required if you want to distribute the sign-up links to
-                venueless for your speakers by way of pretalx.
+                Eventyay video for your speakers by way of pretalx.
             {% endblocktranslate %}
         </p>
 

--- a/pretalx_venueless/urls.py
+++ b/pretalx_venueless/urls.py
@@ -4,17 +4,17 @@ from . import views
 
 urlpatterns = [
     path(
-        "orga/event/<slug:event>/settings/p/venueless/",
+        "orga/event/<slug:event>/settings/p/eventyay-video/",
         views.Settings.as_view(),
         name="settings",
     ),
     path(
-        "<slug:event>/p/venueless/check",
+        "<slug:event>/p/eventyay-video/check",
         views.check,
         name="check",
     ),
     path(
-        "<slug:event>/p/venueless/join",
+        "<slug:event>/p/eventyay-video/join",
         views.SpeakerJoin.as_view(),
         name="join",
     ),

--- a/pretalx_venueless/views.py
+++ b/pretalx_venueless/views.py
@@ -119,9 +119,9 @@ class SpeakerJoin(View):
             "profile": profile,
             "traits": list(
                 {
-                    f"pretalx-event-{request.event.slug}",
+                    f"eventyay-video-event-{request.event.slug}",
                 }
-                | {f"pretalx-session-{submission.code}" for submission in talks}
+                | {f"eventyay-video-session-{submission.code}" for submission in talks}
             ),
         }
         token = jwt.encode(payload, venueless_settings.secret, algorithm="HS256")


### PR DESCRIPTION
Enhance the branding of eventyay-talk plugin for videos and change to own naming conventions
![image](https://github.com/user-attachments/assets/79385bca-0636-4032-aa9d-e1a30c135e22)
![image](https://github.com/user-attachments/assets/03f10fad-84d2-42b7-b86f-9982f42b029a)
